### PR TITLE
feat(ci): add automated release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,43 @@
+name: Publish Extension
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Create ZIP file
+      run: |
+        zip -r extension.zip . \
+          -x "*.git*" \
+          -x ".github/*" \
+          -x "*.md" \
+          -x "LICENSE" \
+          -x "*.DS_Store"
+    
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: false
+    
+    - name: Upload Release Asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./extension.zip
+        asset_name: hirist-plus-extension.zip
+        asset_content_type: application/zip


### PR DESCRIPTION
- Add GitHub Actions workflow for automated releases
- Configure ZIP creation of extension files
- Set up automatic GitHub release creation on version tags
- Add asset upload to releases

This change enables automated publishing when pushing version tags.